### PR TITLE
fixed wrong position bug in max

### DIFF
--- a/tsting.cpp
+++ b/tsting.cpp
@@ -35,8 +35,10 @@ int main()
 	std::pair<const int, int> p {1, 3} ;
 	std::unordered_set<int> s; s.insert(1); s.insert(2); s.insert(23);
 	std::cout << underscore::contains(s.begin(), s.end(), 1212);
-
 	std::cout << underscore::contains(mp.begin(), mp.end(), p);
+	std::vector<int> v ={0,2,1};
+	std::cout << underscore::max(v) - v.begin();
+	std::cout << *underscore::max(v);
 	// auto x = std::find(mp.begin(), mp.end(), p) != mp.end();
 	// std::cout << x << std::endl;
 	// std::cout << x << std::endl;

--- a/underscore.cpp
+++ b/underscore.cpp
@@ -1,6 +1,6 @@
-#include "underscore.hpp"
 #include <cstddef>
 #include <algorithm>
+#include "underscore.hpp"
 namespace underscore{
 
 
@@ -115,7 +115,7 @@ bool any(Iterator begin, Iterator end, Predicate predicate)
 }
 
 template <typename Container>
-typename Container::iterator max(Container container)
+typename Container::iterator max(Container &container)
 {
 	if(container.begin() == container.end())
 		return container.end();


### PR DESCRIPTION
#1 

The container was being passed by value. This was creating a new instance of the container in a different memory location. Thus the difference was a weird value. An & solved the issue