### PR TITLE
remove stdc++ dependency

### DIFF
--- a/testing.cpp
+++ b/testing.cpp
@@ -1,9 +1,9 @@
-#include <bits/stdc++.h>
+#include <iostream>
 #include "underscore.cpp"
 
 void display(int x)
 {
-	std:: cout << x << " " ;
+	std::cout << x << " " ;
 }
 
 int incr(int x)


### PR DESCRIPTION
stdc++.h is not supported outside GNU, this meant compiling issues for testing.cpp on macOS and perhaps in Windows.

Use only what's needed, for now that is iostream for std::cout

Also fixes an extra space that would make the build fail on macOS