### PR TITLE
count_by - issue #61

### DIFF
--- a/testing.cpp
+++ b/testing.cpp
@@ -1,9 +1,9 @@
-#include <bits/stdc++.h>
+#include <iostream>
 #include "underscore.cpp"
 
 void display(int x)
 {
-	std:: cout << x << " " ;
+	std::cout << x << " " ;
 }
 
 int incr(int x)
@@ -95,7 +95,21 @@ int main()
 		std::cout << std::endl;
 	}
 
-	// auto x = std::find(mp.begin(), mp.end(), p) != mp.end();
+	// test count_by
+    std::cout << std::endl << "count_by (is_odd)" << std::endl;
+	auto count_by_bool = _::count_by(vec, is_odd);
+	for(auto &kv : count_by_bool) {
+	    std::cout << kv.first << " " << kv.second << std::endl;
+	}
+
+    std::cout << std::endl << "count_by (mulp)" << std::endl;
+    auto count_by_mulp = _::count_by(vec, mulp);
+    for(auto &kv : count_by_mulp) {
+        std::cout << kv.first << " " << kv.second << std::endl;
+    }
+    std::cout << std::endl;
+
+    // auto x = std::find(mp.begin(), mp.end(), p) != mp.end();
 	// std::cout << x << std::endl;
 	// std::cout << x << std::endl;
 

--- a/underscore.cpp
+++ b/underscore.cpp
@@ -94,7 +94,6 @@ namespace _
 				return false;
 			begin++;
 		}
-
 		return true;
 	}
 
@@ -108,7 +107,6 @@ namespace _
 
 			begin++;
 		}
-
 		return false;
 	}
 
@@ -125,7 +123,6 @@ namespace _
 			if((*max) < (*it))
 				max = it;
 		}
-
 		return max;
 	}
 
@@ -142,7 +139,6 @@ namespace _
 			if((*min) > (*it))
 				min = it;
 		}
-
 		return min;
 	}
 
@@ -179,26 +175,20 @@ namespace _
 				return true;
 			begin++;
 		}
-
 		return false;
-
 	}
 
 
 	template <typename Iterator, typename Data, typename X, typename Y>
 	bool contains(Iterator begin, Iterator end, std::pair<X, Y> p)
 	{
-
 		while(begin != end)
 		{
-
 			if((*begin).first == p.first and (*begin).second == p.second)
 				return true;
 			begin++;
 		}
-
 		return false;
-
 	}
 
 	template <typename Container>
@@ -330,4 +320,15 @@ namespace _
 		}
 		return result;
 	}
+
+    template <typename Container, typename Function>
+    auto count_by(Container &container, Function function) -> std::map<decltype(function(*container.begin())), int>
+    {
+	    std::map<decltype(function(*container.begin())), int> result;
+	    std::map<decltype(function(*container.begin())), std::vector<typename Container::value_type>> grouped_by = group_by(container, function);
+	    for (auto &kv : grouped_by) {
+	    	result[kv.first] = kv.second.size();
+	    }
+	    return result;
+    }
 }

--- a/underscore.hpp
+++ b/underscore.hpp
@@ -51,6 +51,9 @@ Container intersect(Container container1, Container container2, Containers ... o
 template <typename Container, typename Function>
 auto group_by(Container &container, Function function) -> std::map<decltype(function(*container.begin())), std::vector<typename Container::value_type>>;
 
+template <typename Container, typename Function>
+auto count_by(Container &container, Function function) -> std::map<decltype(function(*container.begin())), int>;
+
 template <typename Container, typename ... Containers>
 Container set_union(Container container1, Container container2, Containers  ... others);
 


### PR DESCRIPTION
Also removed a bunch of empty spaces for consistency along underscore.cpp, and I also included the fixes related to removing `stdc++.h` and the dangling space when doing a `std:: cout`, which I included in a separate PR.

If you like this PR, you can ignore the previous one and merge all those fixes in one shot.